### PR TITLE
chore: setup dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,32 @@
+version: 2
+updates:
+  # Maintain dependencies for pnpm
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 10
+    versioning-strategy: auto
+    labels: [dependencies]
+    commit-message:
+      prefix: chore(deps)
+      prefix-development: chore(deps-dev)
+    groups:
+      dev-dependencies:
+        patterns: ['*']
+    ignore:
+      - dependency-name: '*'
+        update-types: [version-update:semver-patch]
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 10
+    labels: [dependencies, github-actions]
+    commit-message:
+      prefix: chore(actions)
+    groups:
+      github-actions:
+        patterns: ['*']


### PR DESCRIPTION
**What**:

Configured Dependabot to update `pnpm` and GitHub Actions dependencies monthly, ignoring small changes (`x.x.*`)

**Why**:

idk

- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged

