### PR TITLE
chore: dont git blame f7531a05ef2eb3701c07eb54f27129a92f41cf09

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# style: disable semi and use single quote style (#33)
+f7531a05ef2eb3701c07eb54f27129a92f41cf09


### PR DESCRIPTION
### Description

Will not show f7531a05ef2eb3701c07eb54f27129a92f41cf09 changes in git blame because there are too many formatting changes that do not provide useful information

