### PR TITLE
copy plugin: fixed directory check, fixed absolute paths processing

### DIFF
--- a/packages/bunup/src/plugins/copy.ts
+++ b/packages/bunup/src/plugins/copy.ts
@@ -1,4 +1,5 @@
-import { basename, extname, join } from 'node:path'
+import fs from 'node:fs'
+import { basename, isAbsolute, join } from 'node:path'
 import type { BuildOptions } from '../options'
 import { logger } from '../printer/logger'
 import type { Arrayable } from '../types'
@@ -151,7 +152,7 @@ class CopyBuilder {
 
 						const finalDestinationPath = resolveDestinationPath(
 							destinationPath,
-							scannedPath,
+							sourcePath,
 							meta.rootDir,
 						)
 
@@ -227,7 +228,9 @@ function resolveDestinationPath(
 	scannedPath: string,
 	rootDir: string,
 ): string {
-	const fullDestinationPath = join(rootDir, destinationPath)
+	const fullDestinationPath = isAbsolute(destinationPath)
+		? destinationPath
+		: join(rootDir, destinationPath)
 	const isScannedPathDir = isDirectoryPath(scannedPath)
 	const isDestinationDir = isDirectoryPath(fullDestinationPath)
 
@@ -239,7 +242,12 @@ function resolveDestinationPath(
 }
 
 function isDirectoryPath(filePath: string): boolean {
-	return extname(filePath) === ''
+	try {
+		const stats = fs.statSync(filePath)
+		return stats.isDirectory()
+	} catch {
+		return false
+	}
 }
 
 async function copyDirectory(


### PR DESCRIPTION
## Description

<!-- Briefly describe what this PR does -->

## Type of Change

<!-- Check the relevant option -->

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance
- [ ] ✅ Tests
- [ ] 🔧 Build/CI

## Related Issues

<!-- Link related issues: Fixes #123, Closes #456 -->

## Changes

<!-- List key changes -->

- replaced a path based check, if the path is a directory, with an actual file system check, so it should fix many edge cases
- fixed the copy plugin paths processing when `outDir` is an absolute path

## Testing

<!-- How did you test this? -->

- [ ] Tests added/updated
- [x] All tests passing

There is none right now. I can include tests, but it will require some changes to the testing helpers too, to accept a custom directory, which will be a temporary directory provided by OS. So let me know.

## Checklist

- [x] Code follows project style
- [x] Self-reviewed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or documented)

## Screenshots/Notes

<!-- Optional: Add screenshots or additional context -->
