### PR TITLE
fix: relax typescript peer dependency range

### DIFF
--- a/packages/bunup/package.json
+++ b/packages/bunup/package.json
@@ -64,7 +64,7 @@
 		"@types/bun": "^1.3.6"
 	},
 	"peerDependencies": {
-		"typescript": "latest"
+		"typescript": ">=4.5.0"
 	},
 	"peerDependenciesMeta": {
 		"typescript": {

--- a/packages/plugin-react-compiler/package.json
+++ b/packages/plugin-react-compiler/package.json
@@ -49,7 +49,7 @@
 		"@types/babel__core": "^7.20.5"
 	},
 	"peerDependencies": {
-		"typescript": "latest"
+		"typescript": ">=4.5.0"
 	},
 	"peerDependenciesMeta": {
 		"typescript": {

--- a/packages/plugin-tailwindcss/package.json
+++ b/packages/plugin-tailwindcss/package.json
@@ -47,7 +47,7 @@
 		"postcss": "^8.5.6"
 	},
 	"peerDependencies": {
-		"typescript": "latest"
+		"typescript": ">=4.5.0"
 	},
 	"peerDependenciesMeta": {
 		"typescript": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -40,7 +40,7 @@
 		"type-check": "tsc --noEmit"
 	},
 	"peerDependencies": {
-		"typescript": "latest"
+		"typescript": ">=4.5.0"
 	},
 	"peerDependenciesMeta": {
 		"typescript": {


### PR DESCRIPTION
Summary
- constrain TypeScript peer dependencies to `>=4.5.0` instead of `latest` across bunup, plugin-react-compiler, plugin-tailwindcss, and shared packages to avoid peer resolution issues
- update peer dependency metadata consistently to match the new range

Testing
- Not run (not requested)