### PR TITLE
fix: prevent `formatBunBuildError` from crashing when line/column are unavailable

### DIFF
--- a/packages/bunup/src/errors.ts
+++ b/packages/bunup/src/errors.ts
@@ -183,6 +183,10 @@ export function formatBunBuildError(error: BuildMessage | ResolveMessage): strin
 	const padding = " ".repeat(lineNum.length);
 	const caretPos = pos.column;
 
+	if (pos.line < 0 || pos.column < 0) {
+		return `${pc.bold(error.message)}
+    ${pc.dim("at")} ${pc.cyan(getShortFilePath(pos.file))}`;
+	}
 	return `${pc.dim(`${lineNum} |`)} ${logger.highlight(pos.lineText)}
 ${pc.dim(`${padding} |`)} ${" ".repeat(caretPos)}${pc.red("^")}
 


### PR DESCRIPTION
## Description

Some Bun build errors provide a `position` object with `line` and `column` set to `-1` instead of omitting the position entirely. In these cases `formatBunBuildError()` attempts to render the location information and eventually calls:

```ts
" ".repeat(pos.column)
```

which throws when `pos.column === -1`.

As a result, the original build error is replaced with:

```text
UNKNOWN ERROR

String.prototype.repeat argument must be greater than or equal to 0 and not be Infinity
```

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance
- [ ] ✅ Tests
- [ ] 🔧 Build/CI

## Related Issues

Fixes #126

## Changes

When the position information does not contain valid line/column values, the formatter now omits the line/column suffix while still displaying:

* the original error message
* the source file path (when available)

This preserves useful debugging information and prevents the formatter itself from throwing.

## Example

Before:

```text
UNKNOWN ERROR

String.prototype.repeat argument must be greater than or equal to 0 and not be Infinity
```

After:

```text
BUILD ERROR

Could not resolve: "react/jsx-dev-runtime". Maybe you need to "bun install"?
    at src/index.ts
```
## Testing

- [ ] Tests added/updated
- [x] All tests passing

## Checklist

- [x] Code follows project style
- [x] Self-reviewed
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or documented)
